### PR TITLE
Proposal for draft-02

### DIFF
--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -301,12 +301,13 @@ discarded after the protocol execution.
 
 Both endpoints MUST either exchange cA=KcA and cB=KcB directly, or employ a
 secure PRF, acting as a MAC that produces pseudorandom tags, for key confirmation.
-In the latter case, KcA and KcB are the symmetric keys used to compute tags cA
-and cB over the received key share of the respective peer.
+In the latter case, KcA and KcB are symmetric keys used to compute tags cA
+and cB over data shared between the participants. That data could for example
+be an encoding of the key shares exchanged earlier, or simply a fixed string.
 
 ~~~
-cA = MAC(KcA, pB)
-cB = MAC(KcB, pA)
+cA = MAC(KcA, ...)
+cB = MAC(KcB, ...)
 ~~~
 
 # Ciphersuites {#Ciphersuites}

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -286,9 +286,7 @@ recomputation of cA or cB and checking for equality against that which was recei
 The protocol transcript TT, as defined in {{spake2plus}},
 is unique and secret to A and B. Both parties use TT to derive shared symmetric
 secrets Ke and Ka. The length of each key is equal to half of the digest output,
-e.g., |Ke| = |Ka| = 128 bits for SHA-256. If the required key size is less than
-half the digest output, e.g. when using SHA-512 to derive two 128-bit keys, the
-digest output MAY be truncated.
+e.g., |Ke| = |Ka| = 128 bits for SHA-256. The shared secret Ke MAY be truncated.
 
 ~~~
 Ka || Ke = Hash(TT)

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -296,7 +296,7 @@ KcA || KcB = KDF(nil, Ka, "ConfirmationKeys")
 ~~~
 
 A and B output Ke as the shared secret from the protocol. Ka and its derived
-KcA and KcB are not used for anything except key confirmation and must be
+KcA and KcB are not used for anything except key confirmation and MUST be
 discarded after the protocol execution.
 
 Both endpoints MUST either exchange cA=KcA and cB=KcB directly, or employ a

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -276,7 +276,7 @@ specific protocol is given in {{?I-D.ietf-mmusic-sdp-uks}}).
 Upon completion of this protocol, A and B compute shared secrets Ka, Ke, KcA,
 and KcB as specified in {{keys}}. B MUST send A a key confirmation message cB
 so both parties can confirm that they agree upon these shared secrets. After
-receipt and verification of B's confirmation message, A MUST send B an equivalent
+receipt and verification of B's confirmation message, A MUST send B a
 confirmation message. B MUST NOT send application data to A until it has received
 and verified the confirmation message. Key confirmation verification requires
 recomputation of cA or cB and checking for equality against that which was received.

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -286,7 +286,7 @@ recomputation of cA or cB and checking for equality against that which was recei
 The protocol transcript TT, as defined in {{spake2plus}},
 is unique and secret to A and B. Both parties use TT to derive shared symmetric
 secrets Ke and Ka. The length of each key is equal to half of the digest output,
-e.g., |Ke| = |Ka| = 128 bits for SHA-256. The shared secret Ke MAY be truncated.
+e.g., |Ke| = |Ka| = 128 bits for SHA-256.
 
 ~~~
 Ka || Ke = Hash(TT)
@@ -307,6 +307,10 @@ be an encoding of the key shares exchanged earlier, or simply a fixed string.
 cA = MAC(KcA, ...)
 cB = MAC(KcB, ...)
 ~~~
+
+Once key confirmation is complete, applications MAY use Ke as an authenticated
+shared secret as needed. For example, applications MAY derive one or more AEAD
+keys and nonces from Ke for subsequent application data encryption.
 
 # Ciphersuites {#Ciphersuites}
 


### PR DESCRIPTION
This PR aims to improve readability a bit. It pulls computations out of the paragraphs and puts them in code blocks -- that should make the protocol easier to understand when skimming it the first time. Some computations were rearranged to take a more common form.

It further adds two insights from Shoup's paper proving it secure: a MAC is not strictly necessary for key confirmation, sending `KcA` and `KcB` is sufficient. The fixed element N might be chosen to have a known discrete log.