### PR TITLE
Make identities A,B mandatory inputs to PBKDF, fixes #12

### DIFF
--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -209,13 +209,11 @@ w0 = w0s mod p
 w1 = w1s mod p
 ~~~
 
-If one or both identities A and B are unknown at the time of deriving w0 and w1,
-w0s and w1s are computed as if the unknown identities were absent, i.e., the length
-of the identity is zero. They however SHOULD be included in the transcript TT if
-the parties exchange those prior to or as part of the protocol flow.
-
-For simplicity, if both identities are absent, i.e. len(A) = len(B) = 0, then
-w0s || w1s = PBKDF(pw).
+If an identity is unknown at the time of computing w0s or w1s, its length is given
+as zero and the identity itself the empty octet string. If both A and B are unkown,
+then both lengths are zero and both A and B will be empty octet strings. Both
+identities however SHOULD be included in the transcript TT if the parties exchange
+those prior to or as part of the protocol flow.
 
 ## Protocol
 

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -212,8 +212,7 @@ w1 = w1s mod p
 If an identity is unknown at the time of computing w0s or w1s, its length is given
 as zero and the identity itself the empty octet string. If both A and B are unknown,
 then both lengths are zero and both A and B will be empty octet strings. Both
-identities however SHOULD be included in the transcript TT if the parties exchange
-those prior to or as part of the protocol flow.
+identities are included in the transcript TT as part of the protocol flow.
 
 ## Protocol
 

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -210,7 +210,7 @@ w1 = w1s mod p
 ~~~
 
 If an identity is unknown at the time of computing w0s or w1s, its length is given
-as zero and the identity itself the empty octet string. If both A and B are unkown,
+as zero and the identity itself the empty octet string. If both A and B are unknown,
 then both lengths are zero and both A and B will be empty octet strings. Both
 identities however SHOULD be included in the transcript TT if the parties exchange
 those prior to or as part of the protocol flow.


### PR DESCRIPTION
Fixes #12 by making identities mandatory inputs to the PBKDF when computing `w0s` and `w1s`.