### PR TITLE
add pseudocode for protocol flow to appendix

### DIFF
--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -529,6 +529,9 @@ def VerifierFinish(w0, L, X):
 
 ## Transcript Computation
 
+Both Prover and Verifier share the same function to compute the protocol
+transcript, ComputeTranscript, which is described below.
+
 ~~~
 def ComputeTranscript(Context, idProver, idVerifier, shareP, shareV, Z, V, w0):
    TT = len(Context) || Context

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -491,6 +491,9 @@ P, p, and h are defined by the chosen ciphersuite.
 
 ## Prover
 
+The Prover's behavior consists of two functions, ProverInit and ProverFinish, which
+are described below.
+
 ~~~
 def ProverInit(w0):
    // Compute prover key share

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -544,6 +544,8 @@ def ComputeTranscript(Context, idProver, idVerifier, shareP, shareV, Z, V, w0):
 ~~~
 
 ## Key Schedule Computation
+Both Prover and Verifier share the same function to compute
+the key schedule, ComputeKeySchedule, which is described below.
 
 ~~~
 def ComputeKeySchedule(TT):

--- a/draft-bar-cfrg-spake2plus.md
+++ b/draft-bar-cfrg-spake2plus.md
@@ -511,6 +511,9 @@ def ProverFinish(w0, w1, x, Y):
 
 ## Verifier
 
+The Verifier's behavior consists of a single function, VerifierFinish, which
+is described below.
+
 ~~~
 def VerifierFinish(w0, L, X):
    if not_in_subgroup(X):


### PR DESCRIPTION
Alternative to #30, moving the whole pseudocode protocol flow description to the appendix.

Should we reference this somewhere?

cc @chris-wood 